### PR TITLE
Miscellaneous tweaks to align formatting with LaTeX template

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -431,7 +431,7 @@
   set list(indent: 10pt, body-indent: 9pt)
 
   // Configure figures
-  set figure(gap: 10pt)
+  set figure(gap: 10pt, supplement: "Fig.")
   show figure.caption: it => {
     set align(left)
     set text(font: sans-serif-font, size: 8pt)

--- a/lib.typ
+++ b/lib.typ
@@ -433,8 +433,10 @@
   // Configure figures
   set figure(gap: 10pt)
   show figure.caption: it => {
+    set align(left)
     set text(font: sans-serif-font, size: 8pt)
     it
+    v(12pt)
   }
 
   // Configure headings

--- a/lib.typ
+++ b/lib.typ
@@ -117,7 +117,7 @@
     if type(it.dest) == str {
       if narrow-doi and regex("https:\\/\\/doi\\.org\\/") in it.dest {
         // DOI links should use narrow font if narrow-doi option is enabled
-        set text(font: narrow-font, stretch: 50%, size: 9pt)
+        set text(font: narrow-font, stretch: 50%, size: 8pt)
         it
       } else {
         // Other URLs should use monospace font like LaTeX \url{}
@@ -379,7 +379,7 @@
     if type(it.dest) == str {
       if narrow-doi and regex("https:\\/\\/doi\\.org\\/") in it.dest {
         // DOI links should use narrow font if narrow-doi option is enabled
-        set text(font: narrow-font, stretch: 50%, size: 9pt)
+        set text(font: narrow-font, stretch: 50%, size: 8pt)
         it
       } else {
         // Other URLs should use monospace font like LaTeX \url{}

--- a/lib.typ
+++ b/lib.typ
@@ -479,10 +479,8 @@
 
   show heading.where(level: 3): it => {
     set par(first-line-indent: 0pt)
-    text(weight: "regular")[
-      #numbering("1.1.1", ..counter(heading).get())
-      #it.body
-    ]
+    show block: set text(weight: "regular")
+    block(above: 12pt, below: 7.2pt, it)
   }
 
   // Display the paper's title.

--- a/lib.typ
+++ b/lib.typ
@@ -176,7 +176,7 @@
   }
 
   // Configure headings
-  set heading(numbering: "1.1.1")
+  set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))
   show heading: set text(font: sans-serif-font, size: 9pt, weight: "bold")
 
   show heading.where(level: 1): it => {
@@ -440,7 +440,7 @@
   }
 
   // Configure headings
-  set heading(numbering: "1.1.1")
+  set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))
   show heading: set text(font: sans-serif-font, size: 9pt, weight: "bold")
 
   show heading.where(level: 1): show-target(paged: it => {


### PR DESCRIPTION
This is a bit of a collection of random small tweaks where I noticed things were not aligned with the LaTeX template. Hopefully you don't mind it all in one pull request since they're all small things, but if you'd prefer for me to split it up I'm happy to do that...after the VIS deadline though. 

- narrow-doi font is now 1pt smaller
- figure captions are now left aligned instead of centered (journal template only)
- all headings have a bit more space between the numbering and the heading itself
- spacing above and below added to h3 as suggested in #26 . I could not reproduce the issue with the heading not working though.
- the supplement for figures is now Fig. instead of Figure. This matches the LaTeX template figure captions and in-text references are now aligned with the ones you get with `\cref{}` (journal template only)