### PR TITLE
Improve heading and figure/table caption formatting + fix regressions

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -60,8 +60,35 @@
   }
 }
 
+// Headings
+#let format-heading-1 = it => {
+  let is-ack = it.body in ([Acknowledgments], [Acknowledgements])
+  
+  set par(first-line-indent: 0pt)
+  set text(weight: "bold")
+  
+  block(above: 14pt, below: 7.6pt, {
+    if it.numbering != none and not is-ack {
+      counter(heading).display()
+      h(9pt, weak: true)
+    }
+    render-smallcaps(it.body)
+  })
+}
+
+#let format-heading-2 = it => {
+    set par(first-line-indent: 0pt)
+    set text(weight: "bold")
+    block(above: 12pt, below: 7.2pt)[#counter(heading).display()#h(8pt)#it.body]
+  }
+
+#let format-heading-3 = it => {
+    set par(first-line-indent: 0pt)
+    block(above: 12pt, below: 7.2pt)[#counter(heading).display()#h(8pt)#it.body]
+  }
+
 // Configure links to use NavyBlue color and monospace font (matching LaTeX hyperref/url settings)
-#let link-formatting = (it, narrow-doi) => {
+#let format-link = (it, narrow-doi) => {
   set text(fill: rgb("#000080")) // NavyBlue (SVG color)
   if type(it.dest) == str {
     if narrow-doi and regex("https:\\/\\/doi\\.org\\/") in it.dest {
@@ -78,7 +105,7 @@
   }
 }
 
-#let caption-formatting = it => {
+#let format-caption = it => {
   set text(font: sans-serif-font, size: 8pt)
   set par(justify: true)
   set block(width: 100%) // to ensure justified text uses full width
@@ -153,7 +180,7 @@
   set text(font: serif-font, size: 9pt)
 
   // Apply link styling.
-  show link: it => link-formatting(it, narrow-doi)
+  show link: it => format-link(it, narrow-doi)
 
   // Configure page
   set page(
@@ -204,38 +231,16 @@
     if it.kind == table {my-supplement = "Table"}
     else {my-supplement = "Figure"}
 
-    caption-formatting([#my-supplement~#it.counter.display()#it.separator#it.body])
+    format-caption([#my-supplement~#it.counter.display()#it.separator#it.body])
   }
 
   // Configure headings
-  set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))
-  show heading: set text(font: sans-serif-font, size: 9pt, weight: "bold")
+  set heading(numbering: "1.1.1")
+  show heading: set text(font: sans-serif-font, size: 9pt, weight: "regular")
 
-  show heading.where(level: 1): it => {
-    let is-ack = it.body in ([Acknowledgments], [Acknowledgements])
-
-    set par(first-line-indent: 0pt)
-    block(above: 12pt, below: 7.2pt)[
-      #if it.numbering != none and not is-ack {
-        numbering("1", ..counter(heading).get())
-        h(7pt, weak: true)
-      }
-      #render-smallcaps(it.body)
-    ]
-  }
-
-  show heading.where(level: 2): it => {
-    set par(first-line-indent: 0pt)
-    block(above: 12pt, below: 7.2pt, it)
-  }
-
-  show heading.where(level: 3): it => {
-    set par(first-line-indent: 0pt)
-    text(weight: "regular")[
-      #numbering("1.1.1", ..counter(heading).get())
-      #it.body
-    ]
-  }
+  show heading.where(level: 1): format-heading-1
+  show heading.where(level: 2): format-heading-2
+  show heading.where(level: 3): format-heading-3
 
   // Title
   v(42pt, weak: true)
@@ -368,7 +373,7 @@
   set text(font: serif-font, size: 9pt)
 
   // Apply link styling.
-  show link: it => link-formatting(it, narrow-doi)
+  show link: it => format-link(it, narrow-doi)
 
   // Configure the page.
   set page(
@@ -411,55 +416,35 @@
 
   // Configure figures
   set figure(gap: 10pt, supplement: "Fig.")
-  show figure.caption: caption-formatting
+  show figure.caption: format-caption
 
   // Configure tables
   show figure.where(kind: table): set figure(supplement: "Tab.")
   show figure.where(kind: table): set figure.caption(position: top)
 
   // Configure headings
-  set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))
-  show heading: set text(font: sans-serif-font, size: 9pt, weight: "bold")
+  set heading(numbering: "1.1.1")
+  show heading: set text(font: sans-serif-font, size: 9pt, weight: "regular")
 
-  show heading.where(level: 1): show-target(paged: it => {
-    let is-ack = it.body in ([Acknowledgments], [Acknowledgements])
-
-    set par(first-line-indent: 0pt)
-    
+  show heading.where(level: 1): show-target(paged: it => {    
+    // specific to journal template: first heading is full width
     if (counter(heading).get() == (1,)) {
-      // first heading is full width
       place(
         top + left,
         float: true,
         scope: "parent",
         {
-          numbering("1", ..counter(heading).get())
-          h(9pt, weak: true)
-          render-smallcaps(it.body)
+          format-heading-1(it)
           v(-6pt)
         },
       )
     } else {
-      block(above: 14pt, below: 7.6pt, {
-        if it.numbering != none and not is-ack {
-          numbering("1", ..counter(heading).get())
-          h(9pt, weak: true)
-        }
-        render-smallcaps(it.body)
-      })
+      format-heading-1(it)
     }
   })
 
-  show heading.where(level: 2): it => {
-    set par(first-line-indent: 0pt)
-    block(above: 12pt, below: 7.2pt, it)
-  }
-
-  show heading.where(level: 3): it => {
-    set par(first-line-indent: 0pt)
-    show block: set text(weight: "regular")
-    block(above: 12pt, below: 7.2pt, it)
-  }
+  show heading.where(level: 2): format-heading-2
+  show heading.where(level: 3): format-heading-3
 
   // Display the paper's title.
   v(3pt, weak: true)

--- a/lib.typ
+++ b/lib.typ
@@ -28,6 +28,56 @@
 #let mono-font = ("Liberation Mono") // LaTeX uses txtt
 #let narrow-font = ("PT Sans")
 
+// Formatting that is identical for both conference and journal templates below
+
+// Custom small caps with dual sizing (hack for fonts without small caps)
+// TODO: Remove when Typst implements synthetic small caps: https://github.com/typst/typst/issues/7009
+#let render-smallcaps(body) = {
+  let render-letter(letter) = {
+    if letter == upper(letter) {
+      text(size: 9pt, letter)
+    } else {
+      text(size: 7pt, upper(letter))
+    }
+    h(0.45pt) // hack to increase tracking
+  }
+  
+  if body.has("text") {
+    for letter in body.text {
+      render-letter(letter)
+    }
+  } else if body.has("children") {
+    for part in body.children {
+      if part.has("text") {
+        for letter in part.text {
+          render-letter(letter)
+        }
+      } else [ ]
+    }
+  } else {
+    show smallcaps: set text(tracking: 0.45pt)
+    smallcaps(body)
+  }
+}
+
+// Configure links to use NavyBlue color and monospace font (matching LaTeX hyperref/url settings)
+#let link-formatting = (it, narrow-doi) => {
+  set text(fill: rgb("#000080")) // NavyBlue (SVG color)
+  if type(it.dest) == str {
+    if narrow-doi and regex("https:\\/\\/doi\\.org\\/") in it.dest {
+      // DOI links should use narrow font if narrow-doi option is enabled
+      set text(font: narrow-font, stretch: 50%, size: 8pt)
+      it
+    } else {
+      // Other URLs should use monospace font like LaTeX \url{}
+      set text(font: mono-font, size: 8pt)
+      it
+    }
+  } else {
+    it
+  }
+}
+
 // This function gets your whole document as its `body` and formats
 // it as a VGTC conference paper.
 #let conference(
@@ -79,55 +129,11 @@
     set document(title: title, author: authors.map(author => author.name))
   }
 
+  // Set the body font.
   set text(font: serif-font, size: 9pt)
 
-  // Custom small caps with dual sizing (hack for fonts without small caps)
-  // TODO: Remove when Typst implements synthetic small caps: https://github.com/typst/typst/issues/7009
-  let render-smallcaps(body) = {
-    let render-letter(letter) = {
-      if letter == upper(letter) {
-        text(size: 9pt, letter)
-      } else {
-        text(size: 7pt, upper(letter))
-      }
-      h(0.45pt) // hack to increase tracking
-    }
-    
-    if body.has("text") {
-      for letter in body.text {
-        render-letter(letter)
-      }
-    } else if body.has("children") {
-      for part in body.children {
-        if part.has("text") {
-          for letter in part.text {
-            render-letter(letter)
-          }
-        } else [ ]
-      }
-    } else {
-      show smallcaps: set text(tracking: 0.45pt)
-      smallcaps(body)
-    }
-  }
-
-  // Configure links to use NavyBlue color and monospace font (matching LaTeX hyperref/url settings)
-  show link: it => {
-    set text(fill: rgb("#000080")) // NavyBlue (SVG color)
-    if type(it.dest) == str {
-      if narrow-doi and regex("https:\\/\\/doi\\.org\\/") in it.dest {
-        // DOI links should use narrow font if narrow-doi option is enabled
-        set text(font: narrow-font, stretch: 50%, size: 8pt)
-        it
-      } else {
-        // Other URLs should use monospace font like LaTeX \url{}
-        set text(font: mono-font, size: 8pt)
-        it
-        }
-    } else {
-      it
-    }
-  }
+  // Apply link styling.
+  show link: it => link-formatting(it, narrow-doi)
 
   // Configure page
   set page(
@@ -258,7 +264,6 @@
   // Two-column layout
   show: show-target(paged: it => columns(2, gutter: 12.24pt)[#it])
   set par(justify: true, first-line-indent: 1em, leading: 0.45em, spacing: 0.45em)
-  set text(font: serif-font, size: 9pt)
 
   // Abstract
   if abstract != none {
@@ -343,53 +348,8 @@
   // Set the body font.
   set text(font: serif-font, size: 9pt)
 
-  // Custom small caps with dual sizing (hack for fonts without small caps)
-  // TODO: Remove when Typst implements synthetic small caps: https://github.com/typst/typst/issues/7009
-  let render-smallcaps(body) = {
-    let render-letter(letter) = {
-      if letter == upper(letter) {
-        text(size: 9pt, letter)
-      } else {
-        text(size: 7pt, upper(letter))
-      }
-      h(0.45pt) // hack to increase tracking
-    }
-    
-    if body.has("text") {
-      for letter in body.text {
-        render-letter(letter)
-      }
-    } else if body.has("children") {
-      for part in body.children {
-        if part.has("text") {
-          for letter in part.text {
-            render-letter(letter)
-          }
-        } else [ ]
-      }
-    } else {
-      show smallcaps: set text(tracking: 0.45pt)
-      smallcaps(body)
-    }
-  }
-
-  // Configure links to use NavyBlue color and monospace font (matching LaTeX hyperref/url settings)
-  show link: it => {
-    set text(fill: rgb("#000080")) // NavyBlue (SVG color)
-    if type(it.dest) == str {
-      if narrow-doi and regex("https:\\/\\/doi\\.org\\/") in it.dest {
-        // DOI links should use narrow font if narrow-doi option is enabled
-        set text(font: narrow-font, stretch: 50%, size: 8pt)
-        it
-      } else {
-        // Other URLs should use monospace font like LaTeX \url{}
-        set text(font: mono-font, size: 8pt)
-        it
-        }
-    } else {
-      it
-    }
-  }
+  // Apply link styling.
+  show link: it => link-formatting(it, narrow-doi)
 
   // Configure the page.
   set page(
@@ -576,8 +536,6 @@
       )
     )
   }
-
-  set text(font: serif-font, size: 9pt)
 
   body
 

--- a/lib.typ
+++ b/lib.typ
@@ -194,12 +194,18 @@
   set enum(indent: 10pt, body-indent: 9pt)
   set list(indent: 10pt, body-indent: 9pt)
 
-  // Configure figures
-  set figure(gap: 10pt)
-  show figure.caption: caption-formatting
-
-  // Configure tables
+  // Configure figures and tables
+  set figure(gap: 10pt, supplement: "Fig.")
+  show figure.where(kind: table): set figure(supplement: "Tab.")
   show figure.where(kind: table): set figure.caption(position: top)
+  show figure.caption: it => {
+    // specifically for conference template: "Figure" and "Table" are not abbreviated in captions
+    let my-supplement
+    if it.kind == table {my-supplement = "Table"}
+    else {my-supplement = "Figure"}
+
+    caption-formatting([#my-supplement~#it.counter.display()#it.separator#it.body])
+  }
 
   // Configure headings
   set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))
@@ -408,7 +414,7 @@
   show figure.caption: caption-formatting
 
   // Configure tables
-  show figure.where(kind: table): set figure(supplement: [Tab.])
+  show figure.where(kind: table): set figure(supplement: "Tab.")
   show figure.where(kind: table): set figure.caption(position: top)
 
   // Configure headings

--- a/lib.typ
+++ b/lib.typ
@@ -198,6 +198,9 @@
   set figure(gap: 10pt)
   show figure.caption: caption-formatting
 
+  // Configure tables
+  show figure.where(kind: table): set figure.caption(position: top)
+
   // Configure headings
   set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))
   show heading: set text(font: sans-serif-font, size: 9pt, weight: "bold")
@@ -403,6 +406,10 @@
   // Configure figures
   set figure(gap: 10pt, supplement: "Fig.")
   show figure.caption: caption-formatting
+
+  // Configure tables
+  show figure.where(kind: table): set figure(supplement: [Tab.])
+  show figure.where(kind: table): set figure.caption(position: top)
 
   // Configure headings
   set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))

--- a/lib.typ
+++ b/lib.typ
@@ -78,6 +78,26 @@
   }
 }
 
+#let caption-formatting = it => {
+  set text(font: sans-serif-font, size: 8pt)
+  set par(justify: true)
+  set block(width: 100%) // to ensure justified text uses full width
+  
+  // one-liner captions are centered, longer captions are left-aligned
+  layout(size => context {
+    let text-size = measure(..size, it)
+    let my-align
+    if text-size.height < 10pt {
+      my-align = center
+    } else {
+      my-align = left
+    }
+    set align(my-align)
+    it
+    v(12pt)
+  })
+}
+
 // This function gets your whole document as its `body` and formats
 // it as a VGTC conference paper.
 #let conference(
@@ -176,10 +196,7 @@
 
   // Configure figures
   set figure(gap: 10pt)
-  show figure.caption: it => {
-    set text(font: sans-serif-font, size: 8pt)
-    it
-  }
+  show figure.caption: caption-formatting
 
   // Configure headings
   set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))
@@ -209,13 +226,6 @@
       #numbering("1.1.1", ..counter(heading).get())
       #it.body
     ]
-  }
-
-  // Conference-specific: center captions and add spacing below figures
-  show figure.caption: set align(center)
-  show figure: it => {
-    it
-    v(8pt)
   }
 
   // Title
@@ -392,12 +402,7 @@
 
   // Configure figures
   set figure(gap: 10pt, supplement: "Fig.")
-  show figure.caption: it => {
-    set align(left)
-    set text(font: sans-serif-font, size: 8pt)
-    it
-    v(12pt)
-  }
+  show figure.caption: caption-formatting
 
   // Configure headings
   set heading(numbering: (..n) => numbering("1.1.1", ..n) + h(4pt))

--- a/lib.typ
+++ b/lib.typ
@@ -121,7 +121,6 @@
     }
     set align(my-align)
     it
-    v(12pt)
   })
 }
 
@@ -223,6 +222,7 @@
 
   // Configure figures and tables
   set figure(gap: 10pt, supplement: "Fig.")
+  show figure: set block(spacing: 12pt)
   show figure.where(kind: table): set figure(supplement: "Tab.")
   show figure.where(kind: table): set figure.caption(position: top)
   show figure.caption: it => {
@@ -416,6 +416,7 @@
 
   // Configure figures
   set figure(gap: 10pt, supplement: "Fig.")
+  show figure: set block(spacing: 12pt)
   show figure.caption: format-caption
 
   // Configure tables


### PR DESCRIPTION
- refactors a little bit as discussed in #30 
- aligns figure caption formatting with LaTeX behavior: centered for single-line captions, left-aligned and justified for multi-line captions (for teaser and all other figures, in both templates)
- improves table captions: now above the table instead of below
- spacing around figures is now set up using block spacing instead of adding `v(12pt)` to the caption styling; this means spacing works correctly for table captions and when figures are placed at the top/bottom of the page
- the correct supplements for figures and tables are now used: Fig. and Tab. in the captions and inline references in most places, but Figure and Table spelled out in the conference template captions
- fixed a regression where inline references to sections had additional spacing added